### PR TITLE
use latest faraday

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.15.0", "!= 0.13.1"]
+  spec.add_runtime_dependency "faraday", [">= 0.9.0", "<= 0.17.3", "!= 0.13.1"]
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.14.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'


### PR DESCRIPTION
test-kitchen is throwing ugly warnings. I think it's due to it's use of forge-ruby (and faraday).

Attempt to fix that.

```
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```